### PR TITLE
refactor: pr 내용 반영한 수정

### DIFF
--- a/music-api/src/main/java/com/music/sale/web/like/LikeCommandController.java
+++ b/music-api/src/main/java/com/music/sale/web/like/LikeCommandController.java
@@ -27,10 +27,8 @@ public class LikeCommandController {
     }
 
     @PostMapping("/products/{productId}/likes")
-    public ResponseEntity<ApiResponse<LikeResponse>> likeProduct(
-            @PathVariable Long productId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<ApiResponse<LikeResponse>> likeProduct(@PathVariable Long productId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         LikeOutput output = addProductLike(userId, productId);
         return createCreatedResponse(output, "LIKE_CREATED");
     }
@@ -48,10 +46,8 @@ public class LikeCommandController {
     }
 
     @DeleteMapping("/products/{productId}/likes")
-    public ResponseEntity<Void> unlikeProduct(
-            @PathVariable Long productId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<Void> unlikeProduct(@PathVariable Long productId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         deleteProductLike(userId, productId);
         return ResponseEntity.noContent().build();
     }
@@ -61,10 +57,8 @@ public class LikeCommandController {
     }
 
     @PostMapping("/stores/{storeId}/likes")
-    public ResponseEntity<ApiResponse<LikeResponse>> subscribeStore(
-            @PathVariable Long storeId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<ApiResponse<LikeResponse>> subscribeStore(@PathVariable Long storeId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         LikeOutput output = addStoreLike(userId, storeId);
         return createCreatedResponse(output, "STORE_SUBSCRIBED");
     }
@@ -74,10 +68,8 @@ public class LikeCommandController {
     }
 
     @DeleteMapping("/stores/{storeId}/likes")
-    public ResponseEntity<Void> unsubscribeStore(
-            @PathVariable Long storeId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<Void> unsubscribeStore(@PathVariable Long storeId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         deleteStoreLike(userId, storeId);
         return ResponseEntity.noContent().build();
     }
@@ -87,10 +79,8 @@ public class LikeCommandController {
     }
 
     @PostMapping("/sellers/{sellerId}/likes")
-    public ResponseEntity<ApiResponse<LikeResponse>> followSeller(
-            @PathVariable Long sellerId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<ApiResponse<LikeResponse>> followSeller(@PathVariable Long sellerId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         LikeOutput output = addSellerLike(userId, sellerId);
         return createCreatedResponse(output, "SELLER_FOLLOWED");
     }
@@ -100,10 +90,8 @@ public class LikeCommandController {
     }
 
     @DeleteMapping("/sellers/{sellerId}/likes")
-    public ResponseEntity<Void> unfollowSeller(
-            @PathVariable Long sellerId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<Void> unfollowSeller(@PathVariable Long sellerId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         deleteSellerLike(userId, sellerId);
         return ResponseEntity.noContent().build();
     }

--- a/music-api/src/main/java/com/music/sale/web/like/LikeQueryController.java
+++ b/music-api/src/main/java/com/music/sale/web/like/LikeQueryController.java
@@ -29,10 +29,8 @@ public class LikeQueryController {
     }
 
     @GetMapping("/products/{productId}/likes/status")
-    public ResponseEntity<ApiResponse<LikeStatusResponse>> getProductLikeStatus(
-            @PathVariable Long productId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<ApiResponse<LikeStatusResponse>> getProductLikeStatus(@PathVariable Long productId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         LikeStatusOutput output = getProductStatus(userId, productId);
         return createStatusResponse(output);
     }
@@ -47,10 +45,10 @@ public class LikeQueryController {
 
     @GetMapping("/users/me/likes/products")
     public ResponseEntity<ApiResponse<Page<Object>>> getMyLikedProducts(
-            @RequestHeader("X-User-Id") Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         Page<Object> likes = findMyProductLikes(userId, page, size);
         return createPageResponse(likes);
     }
@@ -69,10 +67,8 @@ public class LikeQueryController {
     }
 
     @GetMapping("/stores/{storeId}/likes/status")
-    public ResponseEntity<ApiResponse<LikeStatusResponse>> getStoreLikeStatus(
-            @PathVariable Long storeId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<ApiResponse<LikeStatusResponse>> getStoreLikeStatus(@PathVariable Long storeId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         LikeStatusOutput output = getStoreStatus(userId, storeId);
         return createStatusResponse(output);
     }
@@ -83,10 +79,10 @@ public class LikeQueryController {
 
     @GetMapping("/users/me/likes/stores")
     public ResponseEntity<ApiResponse<Page<Object>>> getMySubscribedStores(
-            @RequestHeader("X-User-Id") Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         Page<Object> likes = findMyStoreLikes(userId, page, size);
         return createPageResponse(likes);
     }
@@ -97,10 +93,8 @@ public class LikeQueryController {
     }
 
     @GetMapping("/sellers/{sellerId}/likes/status")
-    public ResponseEntity<ApiResponse<LikeStatusResponse>> getSellerLikeStatus(
-            @PathVariable Long sellerId,
-            @RequestHeader("X-User-Id") Long userId
-    ) {
+    public ResponseEntity<ApiResponse<LikeStatusResponse>> getSellerLikeStatus(@PathVariable Long sellerId) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         LikeStatusOutput output = getSellerStatus(userId, sellerId);
         return createStatusResponse(output);
     }
@@ -111,10 +105,10 @@ public class LikeQueryController {
 
     @GetMapping("/users/me/likes/sellers")
     public ResponseEntity<ApiResponse<Page<Object>>> getMyFollowedSellers(
-            @RequestHeader("X-User-Id") Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
+        Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
         Page<Object> likes = findMySellerLikes(userId, page, size);
         return createPageResponse(likes);
     }

--- a/music-application/src/main/java/com/music/sale/application/like/service/LikeCommandService.java
+++ b/music-application/src/main/java/com/music/sale/application/like/service/LikeCommandService.java
@@ -44,7 +44,7 @@ public class LikeCommandService implements LikeCommandUseCase {
     }
 
     private LikeAlreadyExistsException createDuplicateException(LikeableType type) {
-        return new LikeAlreadyExistsException("이미 " + getLikeableTypeKorean(type) + "한 대상입니다.");
+        return new LikeAlreadyExistsException("이미 " + type.getKorean() + "한 대상입니다.");
     }
 
     private Like saveNewLike(Long userId, Long likeableId, LikeableType likeableType) {
@@ -69,26 +69,7 @@ public class LikeCommandService implements LikeCommandUseCase {
     }
 
     private LikeNotFoundException createNotFoundException(LikeableType type) {
-        return new LikeNotFoundException(getLikeableTypeKorean(type) + " 기록을 찾을 수 없습니다.");
-    }
-
-    private String getLikeableTypeKorean(LikeableType type) {
-        if (isProduct(type)) return "찜";
-        if (isStore(type)) return "구독";
-        if (isSeller(type)) return "팔로우";
-        return "좋아요";
-    }
-
-    private boolean isProduct(LikeableType type) {
-        return type == LikeableType.PRODUCT;
-    }
-
-    private boolean isStore(LikeableType type) {
-        return type == LikeableType.STORE;
-    }
-
-    private boolean isSeller(LikeableType type) {
-        return type == LikeableType.SELLER;
+        return new LikeNotFoundException(type.getKorean() + " 기록을 찾을 수 없습니다.");
     }
 }
 

--- a/music-domain/src/main/java/com/music/sale/domain/like/LikeableType.java
+++ b/music-domain/src/main/java/com/music/sale/domain/like/LikeableType.java
@@ -1,18 +1,18 @@
-// Copyright (C) 2024 Your Name or Company
 package com.music.sale.domain.like;
 
-/**
- * 좋아요 대상 타입
- * 다형적 관계(Polymorphic Association)를 위한 Enum
- */
 public enum LikeableType {
-    /** 상품(product_item)에 대한 좋아요 */
-    PRODUCT,
+    PRODUCT("상품 좋아요"),
+    STORE("매장 구독"),
+    SELLER("판매자 팔로우");
 
-    /** 스토어(stores)에 대한 좋아요(구독) */
-    STORE,
+    private final String korean;
 
-    /** 판매자(users)에 대한 좋아요(팔로우) */
-    SELLER
+    LikeableType(String korean) {
+        this.korean = korean;
+    }
+
+    public String getKorean() {
+        return korean;
+    }
 }
 

--- a/music-infrastructure/src/main/java/com/music/sale/persistence/like/LikeCommandPersistenceAdapter.java
+++ b/music-infrastructure/src/main/java/com/music/sale/persistence/like/LikeCommandPersistenceAdapter.java
@@ -4,21 +4,20 @@ import com.music.sale.application.like.port.outport.LikeCommandPort;
 import com.music.sale.domain.like.Like;
 import com.music.sale.domain.like.LikeableType;
 import com.music.sale.persistence.like.entity.LikeEntity;
+import com.music.sale.persistence.like.mapper.LikeEntityMapper;
 import com.music.sale.persistence.like.repository.LikeRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * 좋아요 Command Persistence Adapter (쓰기 전용)
- * CQRS 패턴: Command(쓰기)와 Query(읽기) 분리
- */
 @Repository
 @Transactional
 public class LikeCommandPersistenceAdapter implements LikeCommandPort {
     private final LikeRepository likeRepository;
+    private final LikeEntityMapper likeEntityMapper;
 
-    public LikeCommandPersistenceAdapter(LikeRepository likeRepository) {
+    public LikeCommandPersistenceAdapter(LikeRepository likeRepository, LikeEntityMapper likeEntityMapper) {
         this.likeRepository = likeRepository;
+        this.likeEntityMapper = likeEntityMapper;
     }
 
     @Override
@@ -29,7 +28,7 @@ public class LikeCommandPersistenceAdapter implements LikeCommandPort {
     }
 
     private LikeEntity convertToEntity(Like like) {
-        return LikeEntity.fromDomain(like);
+        return likeEntityMapper.toEntity(like);
     }
 
     private LikeEntity saveEntity(LikeEntity entity) {
@@ -37,7 +36,7 @@ public class LikeCommandPersistenceAdapter implements LikeCommandPort {
     }
 
     private Like convertToDomain(LikeEntity entity) {
-        return entity.toDomain();
+        return likeEntityMapper.toDomain(entity);
     }
 
     @Override

--- a/music-infrastructure/src/main/java/com/music/sale/persistence/like/LikeQueryPersistenceAdapter.java
+++ b/music-infrastructure/src/main/java/com/music/sale/persistence/like/LikeQueryPersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.music.sale.application.like.port.outport.LikeQueryPort;
 import com.music.sale.domain.like.Like;
 import com.music.sale.domain.like.LikeableType;
 import com.music.sale.persistence.like.entity.LikeEntity;
+import com.music.sale.persistence.like.mapper.LikeEntityMapper;
 import com.music.sale.persistence.like.repository.LikeRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -12,17 +13,15 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * 좋아요 Query Persistence Adapter (읽기 전용)
- * CQRS 패턴: Command(쓰기)와 Query(읽기) 분리
- */
 @Repository
 @Transactional(readOnly = true)
 public class LikeQueryPersistenceAdapter implements LikeQueryPort {
     private final LikeRepository likeRepository;
+    private final LikeEntityMapper likeEntityMapper;
 
-    public LikeQueryPersistenceAdapter(LikeRepository likeRepository) {
+    public LikeQueryPersistenceAdapter(LikeRepository likeRepository, LikeEntityMapper likeEntityMapper) {
         this.likeRepository = likeRepository;
+        this.likeEntityMapper = likeEntityMapper;
     }
 
     @Override
@@ -45,7 +44,7 @@ public class LikeQueryPersistenceAdapter implements LikeQueryPort {
     }
 
     private Page<Like> findAndConvert(Long userId, LikeableType likeableType, PageRequest pageRequest) {
-        return findEntities(userId, likeableType, pageRequest).map(LikeEntity::toDomain);
+        return findEntities(userId, likeableType, pageRequest).map(likeEntityMapper::toDomain);
     }
 
     private Page<LikeEntity> findEntities(Long userId, LikeableType likeableType, PageRequest pageRequest) {

--- a/music-infrastructure/src/main/java/com/music/sale/persistence/like/LikeQueryPersistenceAdapter.java
+++ b/music-infrastructure/src/main/java/com/music/sale/persistence/like/LikeQueryPersistenceAdapter.java
@@ -6,6 +6,7 @@ import com.music.sale.domain.like.LikeableType;
 import com.music.sale.persistence.like.entity.LikeEntity;
 import com.music.sale.persistence.like.mapper.LikeEntityMapper;
 import com.music.sale.persistence.like.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,14 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class LikeQueryPersistenceAdapter implements LikeQueryPort {
     private final LikeRepository likeRepository;
     private final LikeEntityMapper likeEntityMapper;
-
-    public LikeQueryPersistenceAdapter(LikeRepository likeRepository, LikeEntityMapper likeEntityMapper) {
-        this.likeRepository = likeRepository;
-        this.likeEntityMapper = likeEntityMapper;
-    }
 
     @Override
     public boolean exists(Long userId, Long likeableId, LikeableType likeableType) {

--- a/music-infrastructure/src/main/java/com/music/sale/persistence/like/entity/LikeEntity.java
+++ b/music-infrastructure/src/main/java/com/music/sale/persistence/like/entity/LikeEntity.java
@@ -1,6 +1,5 @@
 package com.music.sale.persistence.like.entity;
 
-import com.music.sale.domain.like.Like;
 import com.music.sale.domain.like.LikeableType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -54,26 +53,6 @@ public class LikeEntity {
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    /**
-     * Entity -> Domain 변환
-     */
-    public Like toDomain() {
-        return Like.of(id, userId, likeableId, likeableType, createdAt);
-    }
-
-    /**
-     * Domain -> Entity 변환 (Builder 패턴 사용)
-     */
-    public static LikeEntity fromDomain(Like like) {
-        return LikeEntity.builder()
-                .id(like.getId())
-                .userId(like.getUserId())
-                .likeableId(like.getLikeableId())
-                .likeableType(like.getLikeableType())
-                .createdAt(like.getCreatedAt())
-                .build();
-    }
 
     @PrePersist
     protected void onCreate() {

--- a/music-infrastructure/src/main/java/com/music/sale/persistence/like/mapper/LikeEntityMapper.java
+++ b/music-infrastructure/src/main/java/com/music/sale/persistence/like/mapper/LikeEntityMapper.java
@@ -1,0 +1,30 @@
+package com.music.sale.persistence.like.mapper;
+
+import com.music.sale.domain.like.Like;
+import com.music.sale.persistence.like.entity.LikeEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LikeEntityMapper {
+
+    public Like toDomain(LikeEntity entity) {
+        return Like.of(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getLikeableId(),
+                entity.getLikeableType(),
+                entity.getCreatedAt()
+        );
+    }
+
+    public LikeEntity toEntity(Like domain) {
+        return LikeEntity.builder()
+                .id(domain.getId())
+                .userId(domain.getUserId())
+                .likeableId(domain.getLikeableId())
+                .likeableType(domain.getLikeableType())
+                .createdAt(domain.getCreatedAt())
+                .build();
+    }
+}
+


### PR DESCRIPTION
## 작업 내용

이전 pr 피드백 내용 반영한 수정

## 변경 사항

### 1. LikeableType enum에 korean 필드 추가
- 상수를 enum으로 관리하도록 변경
- getLikeableTypeKorean() 메서드 제거
- LikeableType.getKorean() 메서드로 한글 이름 조회

### 2. Entity의 toDomain() 메서드를 Mapper로 분리
- LikeEntityMapper 생성
- Entity ↔ Domain 변환 로직을 Mapper로 이동
- Infrastructure 레이어의 책임 분리

### 3. User 인증 처리 방식 변경
- @RequestHeader("X-User-Id") 제거
- Controller 내부에서 userId = 1L (mock) 형태로 변경
- TODO 주석 추가: "Session에서 가져오도록 수정 예정"

### 4. 명시적 생성자 제거 및 @RequiredArgsConstructor 적용
- LikeQueryPersistenceAdapter에서 명시적 생성자 제거
- @RequiredArgsConstructor 어노테이션 사용으로 변경

## 관련 이슈

Closes #10
Closes #12

재검토 부탁드립니다.