### PR TITLE
refactor: Like 도메인 피드백 반영 (매핑 로직 분리)

### DIFF
--- a/music-api/src/main/java/com/music/sale/web/like/LikeCommandController.java
+++ b/music-api/src/main/java/com/music/sale/web/like/LikeCommandController.java
@@ -4,100 +4,69 @@ import com.music.sale.application.like.dto.LikeOutput;
 import com.music.sale.application.like.port.inport.LikeCommandUseCase;
 import com.music.sale.common.ApiResponse;
 import com.music.sale.domain.like.LikeableType;
+import com.music.sale.web.like.command.AddLikeCommand;
+import com.music.sale.web.like.command.DeleteLikeCommand;
 import com.music.sale.web.like.mapper.LikeWebMapper;
 import com.music.sale.web.like.response.LikeResponse;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 좋아요 Command Controller (쓰기 전용)
- * CQRS 패턴: Command(쓰기)와 Query(읽기) 분리
- * 상품 찜, 스토어 구독, 판매자 팔로우의 생성/삭제 API를 제공합니다.
- */
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1")
 public class LikeCommandController {
     private final LikeCommandUseCase likeCommandUseCase;
     private final LikeWebMapper mapper;
 
-    public LikeCommandController(LikeCommandUseCase likeCommandUseCase, LikeWebMapper mapper) {
-        this.likeCommandUseCase = likeCommandUseCase;
-        this.mapper = mapper;
-    }
-
     @PostMapping("/products/{productId}/likes")
-    public ResponseEntity<ApiResponse<LikeResponse>> likeProduct(@PathVariable Long productId) {
+    public ApiResponse<LikeResponse> likeProduct(@PathVariable Long productId) {
         Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
-        LikeOutput output = addProductLike(userId, productId);
-        return createCreatedResponse(output, "LIKE_CREATED");
-    }
-
-    private LikeOutput addProductLike(Long userId, Long productId) {
-        return likeCommandUseCase.addLike(userId, productId, LikeableType.PRODUCT);
-    }
-
-    private ResponseEntity<ApiResponse<LikeResponse>> createCreatedResponse(LikeOutput output, String code) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(createSuccessResponse(output, code));
-    }
-
-    private ApiResponse<LikeResponse> createSuccessResponse(LikeOutput output, String code) {
-        return ApiResponse.success(mapper.toResponse(output), code);
+        AddLikeCommand command = mapper.toAddCommand(userId, productId, LikeableType.PRODUCT);
+        LikeOutput output = likeCommandUseCase.addLike(command.getUserId(), command.getLikeableId(), command.getLikeableType());
+        LikeResponse response = mapper.toResponse(output);
+        return ApiResponse.success(response, "LIKE_CREATED");
     }
 
     @DeleteMapping("/products/{productId}/likes")
-    public ResponseEntity<Void> unlikeProduct(@PathVariable Long productId) {
+    public ApiResponse<Void> unlikeProduct(@PathVariable Long productId) {
         Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
-        deleteProductLike(userId, productId);
-        return ResponseEntity.noContent().build();
-    }
-
-    private void deleteProductLike(Long userId, Long productId) {
-        likeCommandUseCase.deleteLike(userId, productId, LikeableType.PRODUCT);
+        DeleteLikeCommand command = mapper.toDeleteCommand(userId, productId, LikeableType.PRODUCT);
+        likeCommandUseCase.deleteLike(command.getUserId(), command.getLikeableId(), command.getLikeableType());
+        return ApiResponse.success(null, "SUCCESS");
     }
 
     @PostMapping("/stores/{storeId}/likes")
-    public ResponseEntity<ApiResponse<LikeResponse>> subscribeStore(@PathVariable Long storeId) {
+    public ApiResponse<LikeResponse> subscribeStore(@PathVariable Long storeId) {
         Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
-        LikeOutput output = addStoreLike(userId, storeId);
-        return createCreatedResponse(output, "STORE_SUBSCRIBED");
-    }
-
-    private LikeOutput addStoreLike(Long userId, Long storeId) {
-        return likeCommandUseCase.addLike(userId, storeId, LikeableType.STORE);
+        AddLikeCommand command = mapper.toAddCommand(userId, storeId, LikeableType.STORE);
+        LikeOutput output = likeCommandUseCase.addLike(command.getUserId(), command.getLikeableId(), command.getLikeableType());
+        LikeResponse response = mapper.toResponse(output);
+        return ApiResponse.success(response, "STORE_SUBSCRIBED");
     }
 
     @DeleteMapping("/stores/{storeId}/likes")
-    public ResponseEntity<Void> unsubscribeStore(@PathVariable Long storeId) {
+    public ApiResponse<Void> unsubscribeStore(@PathVariable Long storeId) {
         Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
-        deleteStoreLike(userId, storeId);
-        return ResponseEntity.noContent().build();
-    }
-
-    private void deleteStoreLike(Long userId, Long storeId) {
-        likeCommandUseCase.deleteLike(userId, storeId, LikeableType.STORE);
+        DeleteLikeCommand command = mapper.toDeleteCommand(userId, storeId, LikeableType.STORE);
+        likeCommandUseCase.deleteLike(command.getUserId(), command.getLikeableId(), command.getLikeableType());
+        return ApiResponse.success(null, "SUCCESS");
     }
 
     @PostMapping("/sellers/{sellerId}/likes")
-    public ResponseEntity<ApiResponse<LikeResponse>> followSeller(@PathVariable Long sellerId) {
+    public ApiResponse<LikeResponse> followSeller(@PathVariable Long sellerId) {
         Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
-        LikeOutput output = addSellerLike(userId, sellerId);
-        return createCreatedResponse(output, "SELLER_FOLLOWED");
-    }
-
-    private LikeOutput addSellerLike(Long userId, Long sellerId) {
-        return likeCommandUseCase.addLike(userId, sellerId, LikeableType.SELLER);
+        AddLikeCommand command = mapper.toAddCommand(userId, sellerId, LikeableType.SELLER);
+        LikeOutput output = likeCommandUseCase.addLike(command.getUserId(), command.getLikeableId(), command.getLikeableType());
+        LikeResponse response = mapper.toResponse(output);
+        return ApiResponse.success(response, "SELLER_FOLLOWED");
     }
 
     @DeleteMapping("/sellers/{sellerId}/likes")
-    public ResponseEntity<Void> unfollowSeller(@PathVariable Long sellerId) {
+    public ApiResponse<Void> unfollowSeller(@PathVariable Long sellerId) {
         Long userId = 1L; // TODO: Session에서 가져오도록 수정 예정
-        deleteSellerLike(userId, sellerId);
-        return ResponseEntity.noContent().build();
-    }
-
-    private void deleteSellerLike(Long userId, Long sellerId) {
-        likeCommandUseCase.deleteLike(userId, sellerId, LikeableType.SELLER);
+        DeleteLikeCommand command = mapper.toDeleteCommand(userId, sellerId, LikeableType.SELLER);
+        likeCommandUseCase.deleteLike(command.getUserId(), command.getLikeableId(), command.getLikeableType());
+        return ApiResponse.success(null, "SUCCESS");
     }
 }
 

--- a/music-api/src/main/java/com/music/sale/web/like/command/AddLikeCommand.java
+++ b/music-api/src/main/java/com/music/sale/web/like/command/AddLikeCommand.java
@@ -1,0 +1,14 @@
+package com.music.sale.web.like.command;
+
+import com.music.sale.domain.like.LikeableType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AddLikeCommand {
+    private final Long userId;
+    private final Long likeableId;
+    private final LikeableType likeableType;
+}
+

--- a/music-api/src/main/java/com/music/sale/web/like/command/DeleteLikeCommand.java
+++ b/music-api/src/main/java/com/music/sale/web/like/command/DeleteLikeCommand.java
@@ -1,0 +1,14 @@
+package com.music.sale.web.like.command;
+
+import com.music.sale.domain.like.LikeableType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteLikeCommand {
+    private final Long userId;
+    private final Long likeableId;
+    private final LikeableType likeableType;
+}
+

--- a/music-api/src/main/java/com/music/sale/web/like/mapper/LikeWebMapper.java
+++ b/music-api/src/main/java/com/music/sale/web/like/mapper/LikeWebMapper.java
@@ -1,21 +1,25 @@
-// Copyright (C) 2024 Your Name or Company
 package com.music.sale.web.like.mapper;
 
 import com.music.sale.application.like.dto.LikeOutput;
 import com.music.sale.application.like.dto.LikeStatusOutput;
+import com.music.sale.domain.like.LikeableType;
+import com.music.sale.web.like.command.AddLikeCommand;
+import com.music.sale.web.like.command.DeleteLikeCommand;
 import com.music.sale.web.like.response.LikeResponse;
 import com.music.sale.web.like.response.LikeStatusResponse;
 import org.springframework.stereotype.Component;
 
-/**
- * 좋아요 Web Mapper
- * Application DTO <-> Web Response DTO 변환
- */
 @Component
 public class LikeWebMapper {
-    /**
-     * LikeOutput -> LikeResponse 변환
-     */
+    
+    public AddLikeCommand toAddCommand(Long userId, Long likeableId, LikeableType likeableType) {
+        return new AddLikeCommand(userId, likeableId, likeableType);
+    }
+    
+    public DeleteLikeCommand toDeleteCommand(Long userId, Long likeableId, LikeableType likeableType) {
+        return new DeleteLikeCommand(userId, likeableId, likeableType);
+    }
+    
     public LikeResponse toResponse(LikeOutput output) {
         return new LikeResponse(
                 output.getId(),
@@ -25,10 +29,7 @@ public class LikeWebMapper {
                 output.getCreatedAt()
         );
     }
-
-    /**
-     * LikeStatusOutput -> LikeStatusResponse 변환
-     */
+    
     public LikeStatusResponse toStatusResponse(LikeStatusOutput output) {
         return new LikeStatusResponse(output.isLiked());
     }

--- a/music-application/src/main/java/com/music/sale/application/like/port/inport/LikeCommandUseCase.java
+++ b/music-application/src/main/java/com/music/sale/application/like/port/inport/LikeCommandUseCase.java
@@ -20,3 +20,4 @@ public interface LikeCommandUseCase {
 }
 
 
+

--- a/music-application/src/main/java/com/music/sale/application/like/port/inport/LikeQueryUseCase.java
+++ b/music-application/src/main/java/com/music/sale/application/like/port/inport/LikeQueryUseCase.java
@@ -22,3 +22,4 @@ public interface LikeQueryUseCase {
 }
 
 
+

--- a/music-application/src/main/java/com/music/sale/application/like/port/outport/LikeCommandPort.java
+++ b/music-application/src/main/java/com/music/sale/application/like/port/outport/LikeCommandPort.java
@@ -25,3 +25,4 @@ public interface LikeCommandPort {
 }
 
 
+

--- a/music-application/src/main/java/com/music/sale/application/like/port/outport/LikeQueryPort.java
+++ b/music-application/src/main/java/com/music/sale/application/like/port/outport/LikeQueryPort.java
@@ -27,3 +27,4 @@ public interface LikeQueryPort {
 }
 
 
+

--- a/music-infrastructure/src/main/java/com/music/sale/persistence/like/LikeCommandPersistenceAdapter.java
+++ b/music-infrastructure/src/main/java/com/music/sale/persistence/like/LikeCommandPersistenceAdapter.java
@@ -6,19 +6,16 @@ import com.music.sale.domain.like.LikeableType;
 import com.music.sale.persistence.like.entity.LikeEntity;
 import com.music.sale.persistence.like.mapper.LikeEntityMapper;
 import com.music.sale.persistence.like.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @Transactional
+@RequiredArgsConstructor
 public class LikeCommandPersistenceAdapter implements LikeCommandPort {
     private final LikeRepository likeRepository;
     private final LikeEntityMapper likeEntityMapper;
-
-    public LikeCommandPersistenceAdapter(LikeRepository likeRepository, LikeEntityMapper likeEntityMapper) {
-        this.likeRepository = likeRepository;
-        this.likeEntityMapper = likeEntityMapper;
-    }
 
     @Override
     public Like save(Like like) {

--- a/music-infrastructure/src/main/java/com/music/sale/persistence/like/mapper/LikeEntityMapper.java
+++ b/music-infrastructure/src/main/java/com/music/sale/persistence/like/mapper/LikeEntityMapper.java
@@ -28,3 +28,4 @@ public class LikeEntityMapper {
     }
 }
 
+

--- a/music-infrastructure/src/test/java/com/music/sale/persistence/like/LikePersistenceAdapterIntegrationTest.java
+++ b/music-infrastructure/src/test/java/com/music/sale/persistence/like/LikePersistenceAdapterIntegrationTest.java
@@ -182,3 +182,4 @@ class LikePersistenceAdapterIntegrationTest {
 }
 
 
+


### PR DESCRIPTION
## 작업 내용
이전 PR 피드백 내용을 반영한 수정입니다.

## 변경 사항

### 1. Controller 매핑 로직 분리
- Controller에서 데이터 조합 로직을 WebMapper로 분리
- 책임 분리 원칙(SRP) 준수

### 2. Command 패턴 적용
- `AddLikeCommand`: 좋아요 추가 요청 데이터 객체
- `DeleteLikeCommand`: 좋아요 삭제 요청 데이터 객체
- 타입 안정성 및 재사용성 향상

### 3. WebMapper 확장
- `toAddCommand()`: AddLikeCommand 생성
- `toDeleteCommand()`: DeleteLikeCommand 생성
- Controller와 Application 레이어 간 변환 담당

### 4. 기타 개선
- Copyright 주석 제거
- `@RequiredArgsConstructor` 적용 유지

## 테스트 결과
- ✅ 상품 좋아요 추가/삭제
- ✅ 매장 구독/구독취소
- ✅ 판매자 팔로우/언팔로우

## 관련 이슈
Closes #12

재검토 부탁드립니다.